### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ import (
 )
 ```
 
+## Installation
+
+Either install by running `go get github.com/vasi-stripe/gogroup/cmd/gogroup` or, 
+if you have cloned the code, run `go install ./...` from the cloned dir.
+
 ## Usage
 
 Check which files validate this order:
@@ -99,7 +104,6 @@ All of these allow doc comments and named imports.
 
 * Write tests, check coverage
 * Check lint
-* Write better README
 * Improve validation messages
 * Figure out what to do with different structures:
 	* Multiple import declarations. Are these allowed? Do we merge these together?


### PR DESCRIPTION
I think the README is nice as is except that it lacks installation instructions. Note that the instructions in this PR does not currently work as the import path in `gogroup.go` does not begin with hostname. I believe that merging my other PR will solve that…