### PR TITLE
Fix golint warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ All of these allow doc comments and named imports.
 ## TODO
 
 * Write tests, check coverage
-* Check lint
 * Write better README
 * Improve validation messages
 * Figure out what to do with different structures:

--- a/cmd/gogroup/main.go
+++ b/cmd/gogroup/main.go
@@ -42,9 +42,9 @@ func (g *grouper) Group(pkg string) int {
 	// A dot distinguishes non-standard packages.
 	if strings.Contains(pkg, ".") {
 		return g.other
-	} else {
-		return g.std
 	}
+
+	return g.std
 }
 
 func (g *grouper) wasSet() bool {

--- a/repair.go
+++ b/repair.go
@@ -130,10 +130,10 @@ func (p *Processor) reformat(fileName string, r io.Reader) (io.Reader, error) {
 		if bytes.Equal(src, formatted) {
 			// No change by either goimports or grouping.
 			return nil, nil
-		} else {
-			// Format changed, but no imports rewrites needed.
-			return bytes.NewReader(formatted), nil
 		}
+
+		// Format changed, but no imports rewrites needed.
+		return bytes.NewReader(formatted), nil
 	}
 	return ret, nil
 }


### PR DESCRIPTION
After these two lint fixes the project should get 100% on everything except license on https://goreportcard.com/report/github.com/vasi-stripe/gogroup :-)