### PR TITLE
Update installation instructions for modern go

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ import (
 
 ## Installation
 
-Either install by running `go get github.com/vasi-stripe/gogroup/cmd/gogroup` or, 
-if you have cloned the code, run `go install ./...` from the cloned dir.
+Either install by running `go install github.com/vasi-stripe/gogroup/cmd/gogroup@latest` (>= go 1.17), 
+`go get github.com/vasi-stripe/gogroup/cmd/gogroup` (< go 1.17) or, if you have cloned the code, run 
+`go install ./...` from the cloned dir.
 
 ## Usage
 


### PR DESCRIPTION
I reinstalled my computer and had to install `gogroup` again and ran into this problem :-)

I still use `gogroup` almost daily so think its important that the installation instructions work! Thanks!